### PR TITLE
Pipeline queue (orchestrator wake)

### DIFF
--- a/docs/pipeline/queue-wake-placeholder.md
+++ b/docs/pipeline/queue-wake-placeholder.md
@@ -1,0 +1,3 @@
+# Pipeline queue (orchestrator wake)
+
+Doorbell-only draft PR. See `docs/pipeline/QUEUE_WAKE.md` on main.


### PR DESCRIPTION
Bootstrap doorbell PR. Overseer adds label `orchestrator-wake` here to start Orchestrator. **Not a ticket** — no cursor-job, never merge. Worker/QA ignore.